### PR TITLE
Fix ssh key provisioning for vagrant box

### DIFF
--- a/.vagrant/ssh/ubuntu1404.deploy.local.dev.keys.sh
+++ b/.vagrant/ssh/ubuntu1404.deploy.local.dev.keys.sh
@@ -13,4 +13,5 @@ fi
 mkdir -p /home/vagrant/.ssh
 touch /home/vagrant/.ssh/authorized_keys
 chown -R vagrant: /home/vagrant/.ssh
+sed -i -e '$a\' /home/vagrant/.ssh/authorized_keys
 cat /home/vagrant/.ssh/id_rsa.pub >> /home/vagrant/.ssh/authorized_keys


### PR DESCRIPTION
Add a newline (if it doesn't exist yet) to the `authorized_keys` file when provisioning vagrant box.
